### PR TITLE
fix: orders container height

### DIFF
--- a/src/pages/public/orders/index.scss
+++ b/src/pages/public/orders/index.scss
@@ -1,69 +1,70 @@
 /* width */
 ::-webkit-scrollbar {
-  width: 5px;
+	width: 5px;
 }
 
 /* Track */
 ::-webkit-scrollbar-track {
-  background: #3A3A3C;
-  border-radius: 20px;}
+	background: #3a3a3c;
+	border-radius: 20px;
+}
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-  background: #FFAE00;
-  border-radius: 10px;
+	background: #ffae00;
+	border-radius: 10px;
 }
 
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(247, 147, 26, 0.64);
+	background: rgba(247, 147, 26, 0.64);
 }
 
-
 .orders-container {
-  overflow-y: auto;
-  height: 580px;
+	overflow-y: auto;
+	height: 100%;
+	max-height: 540px;
 
-  .order-list-item {
-    .order-list-item-date {
-      font-weight: 600;
-      font-size: 24px;
-      letter-spacing: -0.5px;
-      color: #FFFFFF;
-      margin-bottom: 20px;
-    }
+	.order-list-item {
+		.order-list-item-date {
+			font-weight: 600;
+			font-size: 24px;
+			letter-spacing: -0.5px;
+			color: #ffffff;
+			margin-bottom: 20px;
+		}
 
-    .order-list-content {
-      display: flex;
-      align-items: flex-end;
+		.order-list-content {
+			display: flex;
+			align-items: flex-end;
 
-      .order-list-details {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
+			.order-list-details {
+				flex: 1;
+				display: flex;
+				flex-direction: column;
 
-        .order-status-heading {
-          font-weight: 600;
-          font-size: 15px;
-          color: #F75C1A;
-          margin-bottom: 10px;
-        }
+				.order-status-heading {
+					font-weight: 600;
+					font-size: 15px;
+					color: #f75c1a;
+					margin-bottom: 10px;
+				}
 
-        .order-status-value {
-          font-size: 21px;
-          line-height: 24px;
-          color: #FFFFFF;
-          font-weight: 200;
+				.order-status-value {
+					font-size: 21px;
+					line-height: 24px;
+					color: #ffffff;
+					font-weight: 200;
 
-          .order-status-icon {
-            margin-right: 13.24px;
-          }
-        }
-      }
-    }
-  }
+					.order-status-icon {
+						margin-right: 13.24px;
+					}
+				}
+			}
+		}
+	}
 
-  .with-scrollbar {
-    padding-right: 20px;
-  }
+	.with-scrollbar {
+		padding-right: 20px;
+	}
 }


### PR DESCRIPTION
## Description
Fix the double scrollbar that was appearing at `my orders` page.
I've also had to lint the `index.scss` file.

## Current Behaviour
![image](https://user-images.githubusercontent.com/5798170/171296471-287bdc15-c2d0-4d3c-878f-fbca86a2cf15.png)

## Expected Behaviour
![image](https://user-images.githubusercontent.com/5798170/171296568-4e6b603f-d43b-43b0-bc22-a64217aa0908.png)
