### PR TITLE
docs: setup environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .idea
+
+.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Recommended resolution for your embedded widget:
 ></iframe>
 ```
 
+## Environment Variables
+
+Create the file `.env` at the root folder.
+
+Get information from `blocktank client` mainnet(true) or testnet (false):
+
+```
+REACT_APP_MAINNET=true
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Recommended resolution for your embedded widget:
 
 ## Environment Variables
 
-Create the file `.env` at the root folder.
+Create `.env` file at the root folder.
 
-Get information from `blocktank client` mainnet(true) or testnet (false):
+Get information from `blocktank-client` mainnet **(true)** or testnet **(false)**:
 
 ```
 REACT_APP_MAINNET=true


### PR DESCRIPTION
## Description

I added more informations about how to setup `blocktank client` using mainnet to the readme file.
The current default network of `blocktank client` is testnet.